### PR TITLE
knowhow-2339: Configure AWS OIDC authentication for S3 uploads

### DIFF
--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -32,10 +36,14 @@ jobs:
         run: |
           go mod tidy
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::064236193412:role/knowhow-gha-animation-upload
+          aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Upload to S3
         run: go run upload_to_s3.go
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           S3_BUCKET: ${{ secrets.S3_BUCKET }}


### PR DESCRIPTION
### Description

Migrates `run_insights_testing_chrome.yml` off the long-lived `IAM access key to GitHub OIDCPart of SOC 2 access-key rotation remediation (knowhow-2339).
<img width="1920" height="1006" alt="screencapture-us-east-1-console-aws-amazon-iam-home-2026-07-22-10_31_45" src="https://github.com/user-attachments/assets/4b49e7e8-bc45-4cea-8600-4c9701b8438a" />

<img width="1920" height="1045" alt="screencapture-us-east-1-console-aws-amazon-iam-home-2026-07-22-12_12_24" src="https://github.com/user-attachments/assets/be5a06c5-62b0-4495-94a4-87633116ce44" />

<img width="1920" height="983" alt="screencapture-us-east-1-console-aws-amazon-iam-home-2026-07-22-12_12_38" src="https://github.com/user-attachments/assets/e9e47753-7692-4566-92e0-2adad74abe9f" />

Changes:
- Added `id-token: write` to all three jobs.
- Swapped `configure-aws-credentials` from access key/secret to `role-to-assume`.

### Required Checks

- [X] Matches acceptance criteria
- [X] Tested locally

### Security Impact Assessment

- [X] Security impact reviewed  
We will be deactivating the old access key that was responsible for deployment pipeline here.
